### PR TITLE
feat: dinamic setup when project id is null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Terragrunt (si lo usas)
+# Terragrunt (if used)
 .terragrunt-cache/
-.terraform.lock.hcl # ← opcional si no quieres compartir versiones bloqueadas
+.terraform.lock.hcl
 
 tf-byoc-module/

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Terragrunt (if used)
+# Terragrunt (si lo usas)
 .terragrunt-cache/
-.terraform.lock.hcl
+.terraform.lock.hcl # ← opcional si no quieres compartir versiones bloqueadas
 
 tf-byoc-module/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -43,7 +43,57 @@ provider "google" {
 
 EOF
 
+if ! command -v gcloud &> /dev/null
+then
+    echo "gcloud is not installed. Please install it first."
+    exit 1
+fi
+
 export TF_VAR_project_id=$(gcloud config get-value project 2>/dev/null)
+
+if [ -z "$TF_VAR_project_id" ]; then
+  
+  echo "Fetching list of GCP projects..."
+  mapfile -t PROJECTS < <(gcloud projects list --format="value(projectId)")
+
+  if [ ${#PROJECTS[@]} -eq 0 ]; then
+      echo "No projects found in your GCP account."
+      exit 1
+  fi
+
+  echo "Available projects:"
+  for i in "${!PROJECTS[@]}"; do
+      echo "$((i+1)). ${PROJECTS[$i]}"
+  done
+
+
+  while true; do
+    read -p "Enter the number of the project you want to use: " SELECTION
+
+    if [[ "$SELECTION" =~ ^[0-9]+$ ]] && [ "$SELECTION" -ge 1 ] && [ "$SELECTION" -le "${#PROJECTS[@]}" ]; then
+        SELECTED_PROJECT="${PROJECTS[$((SELECTION-1))]}"
+        
+        read -p "Are you sure you want to use $SELECTED_PROJECT? (y/n): " CONFIRMATION
+        case "$CONFIRMATION" in
+            [Yy]* ) 
+                echo "Confirmed. Using project: $SELECTED_PROJECT"
+                break
+                ;;
+            [Nn]* )
+                echo "Selection canceled. Please choose again."
+                ;;
+            * )
+                echo "Please answer y (yes) or n (no)."
+                ;;
+        esac
+    else
+        echo "Invalid selection. Please try again."
+    fi
+  done
+
+  gcloud config set project "$SELECTED_PROJECT"
+
+fi
 
 gcloud services enable iam.googleapis.com cloudresourcemanager.googleapis.com
 


### PR DESCRIPTION
When an error occurs and GCP does not automatically assign project ID the script will be shown a dynamic setup to select the project that the user wants to use for LH BYOC.